### PR TITLE
When conditional field was a repeater only the first set was hidden

### DIFF
--- a/web/conditional-fields.js
+++ b/web/conditional-fields.js
@@ -104,7 +104,7 @@
                 if (conditionalFields[name].hasOwnProperty('type')) {
                     switch (conditionalFields[name]['type']) {
                         case 'repeater':
-                            $field = $('[name*="' + name + '[0]"]');
+                            $field = $('[name="' + name + '[]"]');
 
                             break;
                         case 'relation':


### PR DESCRIPTION
When the conditional was applied to a repeater field like so:

```
        template:
            type: templateselect
            filter: 'page_*.twig'

        carousel:
            type: repeater
            limit: 5
            fields:
                image:
                    type: image
                    extensions: [ gif, jpg, png ]
                strapline:
                    type: text
                contentlink:
                    type: text
                    label: Link
                    placeholder: '/slug or http://example.org/'
 
            condition:
                field: template
                operator: '='
                show: true
                value: [ "page_home.twig" ]

        body:
            type: html
            height: 300px
            condition:
                field: template
                operator: '!='
                show: true
                value: [ "page_home.twig" ]
```

Then instead of the whole repeater field being hidden, only the first set of the repeater was. This led to a broken interface like so:

![screen shot 2017-10-23 at 13 36 17](https://user-images.githubusercontent.com/2247922/31889502-fe3a1460-b7f7-11e7-80ae-5b9a7f0ad049.png)

Instead of the whole carousel field not being shown (which I believe is the intended behaviour).
