### PR TITLE
Showing an empty tab for Bolt default tabs

### DIFF
--- a/web/conditional-fields.js
+++ b/web/conditional-fields.js
@@ -452,7 +452,7 @@
 
             // Check which of these are display none (can't use hidden because inactive tabs return as hidden)
             $fields = $fields.filter(function () {
-                return $(this).css("display") !== "none"
+                return $(this).data('bolt-fieldset').length && $(this).css("display") !== "none"
             });
 
             // Show / Hide the tab if it has visible contents


### PR DESCRIPTION
Empty tabs are shown when you create a field with condition and group/tab titled `Taxonomy`.
For some reason there is always an empty div created with attribute `data-bolt-fieldset` for taxonomy tab when it’s used in the CT’s. It looks like it’s Bolt’s default behaviour for that tab.
So when you create `taxonomylist` type fields and set their group as `taxonomy` for pages with conditions to show them only on certain page templates, they still appear in all the templates due to that Bolt’s empty fieldset with the empty data attribute for `data-bolt-fieldset`.
The fix is to check if the data attribute is not empty when counting the visible fields length.